### PR TITLE
Added Custom Mod Config Support.

### DIFF
--- a/src/main/java/com/mrcrayfish/configured/api/ConfiguredHelper.java
+++ b/src/main/java/com/mrcrayfish/configured/api/ConfiguredHelper.java
@@ -1,0 +1,99 @@
+package com.mrcrayfish.configured.api;
+
+import java.util.Map;
+import java.util.Set;
+
+import com.mrcrayfish.configured.client.ClientHandler;
+import com.mrcrayfish.configured.client.screen.ConfigScreen;
+import com.mrcrayfish.configured.client.screen.ModConfigSelectionScreen;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.text.ITextComponent;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
+import net.minecraftforge.fml.ModContainer;
+import net.minecraftforge.fml.config.ModConfig;
+
+/**
+ * 
+ * @author Speiger
+ *
+ * Simple Helper class that allows you to easier find the starting point of how to add your own configured screen.
+ * 
+ */
+public class ConfiguredHelper
+{
+	/**
+	 * Multi Config Screen that automatically loads configs out of a mod if present
+ 	 * Automatically picks the previous screen
+	 * @param title of the ConfigScreen that should be applied.
+	 * @param mod the mod the configs should be loaded from
+	 * @param background of the config screen
+	 * @return a new screen with config selection included
+	 */
+
+	@OnlyIn(Dist.CLIENT)
+	public static Screen createForgeConfiguredScreen(ITextComponent title, ModContainer config, ResourceLocation background)
+	{
+		return createForgeConfiguredScreen(Minecraft.getInstance().currentScreen, title, config, background);
+	}
+	
+	/**
+	 * Multi Config Screen that automatically loads configs out of a mod if present
+	 * @param parent screen that should be returned to after this new gui was closed
+	 * @param title of the ConfigScreen that should be applied.
+	 * @param mod the mod the configs should be loaded from
+	 * @param background of the config screen
+	 * @return a new screen with config selection included
+	 */
+	@OnlyIn(Dist.CLIENT)
+	public static Screen createForgeConfiguredScreen(Screen parent, ITextComponent title, ModContainer mod, ResourceLocation background)
+	{
+		Map<ModConfig.Type, Set<IModConfig>> configs = ClientHandler.createConfigMap(mod);
+		return createConfiguredScreen(parent, title, configs, background);
+	}
+	
+	/**
+	 * Multi Config Screen that allows you to sleect multiple configs at once.
+	 * @param parent screen that should be returned to after this new gui was closed
+	 * @param title of the ConfigScreen that should be applied.
+	 * @param configs the configs that should be in the screen
+	 * @param background of the config screen
+	 * @return a new screen with config selection included
+	 */
+	@OnlyIn(Dist.CLIENT)
+	public static Screen createConfiguredScreen(Screen parent, ITextComponent title, Map<ModConfig.Type, Set<IModConfig>> configs, ResourceLocation background)
+	{
+		return new ModConfigSelectionScreen(parent, title.getString(), background, configs);
+	}
+	
+	/**
+	 * Simple single config screen generator.
+	 * Automatically picks the previous screen
+	 * @param title of the ConfigScreen that should be applied.
+	 * @param config that should be displayed
+	 * @param background of the config screen
+	 * @return Screen for 1 single config file
+	 */
+	@OnlyIn(Dist.CLIENT)
+	public static Screen createConfiguredScreen(ITextComponent title, IModConfig config, ResourceLocation background)
+	{
+		return createConfiguredScreen(Minecraft.getInstance().currentScreen, title, config, background);
+	}
+	
+	/**
+	 * Simple single config screen generator.
+	 * @param parent screen that should be returned to after this new gui was closed
+	 * @param title of the ConfigScreen that should be applied.
+	 * @param config that should be displayed
+	 * @param background of the config screen
+	 * @return Screen for 1 single config file
+	 */
+	@OnlyIn(Dist.CLIENT)
+	public static Screen createConfiguredScreen(Screen parent, ITextComponent title, IModConfig config, ResourceLocation background)
+	{
+		return new ConfigScreen(parent, title, config, background);
+	}
+}

--- a/src/main/java/com/mrcrayfish/configured/api/IConfigEntry.java
+++ b/src/main/java/com/mrcrayfish/configured/api/IConfigEntry.java
@@ -1,0 +1,44 @@
+package com.mrcrayfish.configured.api;
+
+import java.util.List;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * 
+ * @author Speiger
+ * 
+ * Helper interface that allows to visualize the ConfigTree.
+ * It contains all methods that Configured needs to do its work.
+ */
+public interface IConfigEntry
+{
+	/**
+	 * @return list of ChildElements of the current entry. If non are provided return a empty list.
+	 */
+	@Nonnull
+	public List<IConfigEntry> getChildren();
+	/**
+	 * If the Entry is start point of the Configuration Tree
+	 * @return true if it is the root node.
+	 */
+	public boolean isRoot();
+	/**
+	 * Info function to determine if a entry is a value or folder.
+	 * @return true if the config entry is a value.
+	 */
+	public boolean isLeaf();
+	/**
+	 * Returns a Temporary ConfigValue holder that allows users to edit the value without making permanent changes.
+	 * @return a ValueHolder of the current ConfigEntry.
+	 */
+	@Nullable
+	public IConfigValue<?> getValue();
+	/**
+	 * Helper function to return the currents Folder Name.
+	 * @return name of the current folder.
+	 */
+	@Nonnull
+	public String getEntryName();
+}

--- a/src/main/java/com/mrcrayfish/configured/api/IConfigValue.java
+++ b/src/main/java/com/mrcrayfish/configured/api/IConfigValue.java
@@ -64,5 +64,8 @@ public interface IConfigValue<T>
 	@Nonnull
 	public String getPath();
 	
+	/**
+	 * If your config has a cache this is when it should be cleaned
+	 */
 	public void cleanCache();
 }

--- a/src/main/java/com/mrcrayfish/configured/api/IConfigValue.java
+++ b/src/main/java/com/mrcrayfish/configured/api/IConfigValue.java
@@ -1,0 +1,68 @@
+package com.mrcrayfish.configured.api;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * 
+ * @author Speiger
+ * 
+ * @param <T>
+ * 
+ * A Temporary Data Holder that allows to make changes to a Config File without actually changing the config file.
+ * This makes changing the config for the user a lot simpler since the user gets time to validate all its changes.
+ */
+public interface IConfigValue<T>
+{
+	/**
+	 * @return currently set value in the holder.
+	 */
+	@Nonnull
+	public T get();
+	/**
+	 * This method allows to get the Default value specified by the configuration file itself.
+	 * @return the defaultValue from the config.
+	 */
+	@Nonnull
+	public T getDefault();
+	/**
+	 * Sets the current value in the holder.
+	 * @param value to set into the holder.
+	 */
+	public void set(@Nonnull T value);
+	/**
+	 * @param value that should be tested if it can be put into the config.
+	 * @return true if the value presented is correct.
+	 */
+	public boolean isValid(@Nonnull T value);
+	/**
+	 * @return true if the current Holder value is the default value
+	 */
+	public boolean isDefault();
+	/**
+	 * @return true if the current value is different from the value when this object was created
+	 */
+	public boolean isChanged();
+	/**
+	 * Sets the current holder value to the default config value.
+	 */
+	public void restore();
+	/**
+	 * @return the comment of the current config. If present.
+	 */
+	@Nullable
+	public String getComment();
+	/** 
+	 * If the config has translation support included this can return the translation key into the config
+	 * @return the translation key
+	 */
+	@Nullable
+	public String getTranslationKey();
+	/**
+	 * @return current directory name of the config entry this value is in.
+	 */
+	@Nonnull
+	public String getPath();
+	
+	public void cleanCache();
+}

--- a/src/main/java/com/mrcrayfish/configured/api/IModConfig.java
+++ b/src/main/java/com/mrcrayfish/configured/api/IModConfig.java
@@ -36,8 +36,21 @@ public interface IModConfig
 	 */
 	public ModConfig.Type getConfigType();
 	
+	/**
+	 * @return the filename of the config
+	 */
 	public String getFileName();
+	/**
+	 * @return the modId of the config.
+	 */
 	public String getModId();
 	
+	/**
+	 * A Helper function that allows to load the config from the server into the config instance.
+	 * Since this is highly dynamic it has to be done on a per implementation basis.
+	 * @param path to the expected config folder.
+	 * @param result send self if self got updated. if nothing got updated dont push anything into the result
+	 * @throws IOException since its IO work the function will be expected to maybe throw IOExceptions
+	 */
 	public void loadServerConfig(Path path, Consumer<IModConfig> result) throws IOException;
 }

--- a/src/main/java/com/mrcrayfish/configured/api/IModConfig.java
+++ b/src/main/java/com/mrcrayfish/configured/api/IModConfig.java
@@ -1,0 +1,43 @@
+package com.mrcrayfish.configured.api;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.function.Consumer;
+
+import com.mrcrayfish.configured.impl.ForgeConfig;
+
+import net.minecraftforge.fml.config.ModConfig;
+
+/**
+ * 
+ * @author Speiger
+ * 
+ * Config interface that allows you to implement custom config formats into Configured.
+ * This isn't a full automatic system. It is just a interface to make such things actually possible.
+ */
+public interface IModConfig
+{
+	/**
+	 * This function expects you to do everything necessary to save the config.
+	 * If you want a example Lookup {@link ForgeConfig} for how it should be done.
+	 * @param entry the entry that is used or should be checked for updates.
+	 * Also make sure to check children if children of said entry have been changed too.
+	 */
+	public void saveConfig(IConfigEntry entry);
+	/**
+	 * This function returns provides the Entry point of the Configuration File.
+	 * So users can traverse through it.
+	 * @return the root node.
+	 */
+	public IConfigEntry getRoot();
+	/**
+	 * If the configuration file is a server (local world or multiplayer) this function should return true
+	 * @return if the configuration is serversided
+	 */
+	public ModConfig.Type getConfigType();
+	
+	public String getFileName();
+	public String getModId();
+	
+	public void loadServerConfig(Path path, Consumer<IModConfig> result) throws IOException;
+}

--- a/src/main/java/com/mrcrayfish/configured/api/ValueEntry.java
+++ b/src/main/java/com/mrcrayfish/configured/api/ValueEntry.java
@@ -1,0 +1,45 @@
+package com.mrcrayfish.configured.api;
+
+import java.util.Collections;
+import java.util.List;
+
+public class ValueEntry implements IConfigEntry
+{
+	IConfigValue<?> value;
+	
+	public ValueEntry(IConfigValue<?> value)
+	{
+		this.value = value;
+	}
+
+	@Override
+	public List<IConfigEntry> getChildren()
+	{
+		return Collections.emptyList();
+	}
+	
+	@Override
+	public boolean isRoot()
+	{
+		return false;
+	}
+	
+	@Override
+	public boolean isLeaf()
+	{
+		return true;
+	}
+	
+	@Override
+	public IConfigValue<?> getValue()
+	{
+		return value;
+	}
+	
+	@Override
+	public String getEntryName()
+	{
+		return "I am Error";
+	}
+	
+}

--- a/src/main/java/com/mrcrayfish/configured/client/ClientHandler.java
+++ b/src/main/java/com/mrcrayfish/configured/client/ClientHandler.java
@@ -1,11 +1,24 @@
 package com.mrcrayfish.configured.client;
 
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.lwjgl.glfw.GLFW;
+
 import com.mrcrayfish.configured.Config;
 import com.mrcrayfish.configured.Configured;
 import com.mrcrayfish.configured.Reference;
+import com.mrcrayfish.configured.api.IModConfig;
 import com.mrcrayfish.configured.client.screen.IBackgroundTexture;
 import com.mrcrayfish.configured.client.screen.ModConfigSelectionScreen;
 import com.mrcrayfish.configured.client.util.OptiFineHelper;
+import com.mrcrayfish.configured.impl.ForgeConfig;
+
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.AbstractGui;
 import net.minecraft.client.gui.screen.Screen;
@@ -27,15 +40,6 @@ import net.minecraftforge.fml.config.ConfigTracker;
 import net.minecraftforge.fml.config.ModConfig;
 import net.minecraftforge.fml.loading.moddiscovery.ModInfo;
 import net.minecraftforge.forgespi.language.IModInfo;
-import org.lwjgl.glfw.GLFW;
-
-import java.util.Collections;
-import java.util.EnumMap;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * Author: MrCrayfish
@@ -61,7 +65,7 @@ public class ClientHandler
             if(container.getCustomExtension(ExtensionPoint.CONFIGGUIFACTORY).isPresent() && !Config.CLIENT.forceConfiguredMenu.get())
                 return;
 
-            Map<ModConfig.Type, Set<ModConfig>> modConfigMap = createConfigMap(container);
+            Map<ModConfig.Type, Set<IModConfig>> modConfigMap = createConfigMap(container);
             if(!modConfigMap.isEmpty()) // Only add if at least one config exists
             {
                 Configured.LOGGER.info("Registering config factory for mod {}. Found {} client config(s) and {} common config(s)", modId, modConfigMap.getOrDefault(ModConfig.Type.CLIENT, Collections.emptySet()).size(), modConfigMap.getOrDefault(ModConfig.Type.COMMON, Collections.emptySet()).size());
@@ -77,17 +81,16 @@ public class ClientHandler
         return ObfuscationReflectionHelper.getPrivateValue(ConfigTracker.class, ConfigTracker.INSTANCE, "configSets");
     }
 
-    private static Map<ModConfig.Type, Set<ModConfig>> createConfigMap(ModContainer container)
+    public static Map<ModConfig.Type, Set<IModConfig>> createConfigMap(ModContainer container)
     {
-        Map<ModConfig.Type, Set<ModConfig>> modConfigMap = new HashMap<>();
+        Map<ModConfig.Type, Set<IModConfig>> modConfigMap = new HashMap<>();
         addConfigSetToMap(container, ModConfig.Type.CLIENT, modConfigMap);
         addConfigSetToMap(container, ModConfig.Type.COMMON, modConfigMap);
         addConfigSetToMap(container, ModConfig.Type.SERVER, modConfigMap);
         return modConfigMap;
     }
-
-    @SuppressWarnings("SynchronizationOnLocalVariableOrMethodParameter")
-    private static void addConfigSetToMap(ModContainer container, ModConfig.Type type, Map<ModConfig.Type, Set<ModConfig>> configMap)
+    
+    private static void addConfigSetToMap(ModContainer container, ModConfig.Type type, Map<ModConfig.Type, Set<IModConfig>> configMap)
     {
         /* Optifine basically breaks Forge's client config, so it's simply not added */
         if(type == ModConfig.Type.CLIENT && OptiFineHelper.isLoaded() && container.getModId().equals("forge"))
@@ -99,7 +102,7 @@ public class ClientHandler
         Set<ModConfig> configSet = getConfigSets().get(type);
         synchronized(configSet)
         {
-            Set<ModConfig> filteredConfigSets = configSet.stream().filter(config -> config.getModId().equals(container.getModId())).collect(Collectors.toSet());
+            Set<IModConfig> filteredConfigSets = configSet.stream().filter(config -> config.getModId().equals(container.getModId())).map(ForgeConfig::new).collect(Collectors.toSet());
             if(!filteredConfigSets.isEmpty())
             {
                 configMap.put(type, filteredConfigSets);

--- a/src/main/java/com/mrcrayfish/configured/client/screen/WorldSelectionScreen.java
+++ b/src/main/java/com/mrcrayfish/configured/client/screen/WorldSelectionScreen.java
@@ -1,11 +1,19 @@
 package com.mrcrayfish.configured.client.screen;
 
-import com.electronwill.nightconfig.core.file.CommentedFileConfig;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.hash.Hashing;
 import com.mojang.blaze3d.matrix.MatrixStack;
+import com.mrcrayfish.configured.api.IModConfig;
 import com.mrcrayfish.configured.client.util.ScreenUtil;
-import com.mrcrayfish.configured.util.ConfigHelper;
+
 import net.minecraft.client.AnvilConverterException;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.AbstractGui;
@@ -25,16 +33,7 @@ import net.minecraft.world.storage.FolderName;
 import net.minecraft.world.storage.SaveFormat;
 import net.minecraft.world.storage.WorldSummary;
 import net.minecraftforge.fml.ModList;
-import net.minecraftforge.fml.config.ModConfig;
 import net.minecraftforge.fml.loading.FileUtils;
-
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.file.Path;
-import java.util.Collections;
-import java.util.List;
 
 /**
  * Author: MrCrayfish
@@ -44,9 +43,9 @@ public class WorldSelectionScreen extends ListMenuScreen
     private static final FolderName SERVER_CONFIG_FOLDER = new FolderName("serverconfig");
     private static final ResourceLocation MISSING_ICON = new ResourceLocation("textures/misc/unknown_server.png");
 
-    private final ModConfig config;
+    private final IModConfig config;
 
-    public WorldSelectionScreen(Screen parent, ResourceLocation background, ModConfig config, ITextComponent title)
+    public WorldSelectionScreen(Screen parent, ResourceLocation background, IModConfig config, ITextComponent title)
     {
         super(parent, new TranslationTextComponent("configured.gui.edit_world_config", title.copyRaw().mergeStyle(TextFormatting.YELLOW)), background, 30);
         this.config = config;
@@ -179,10 +178,10 @@ public class WorldSelectionScreen extends ListMenuScreen
             {
                 Path serverConfigPath = levelSave.resolveFilePath(SERVER_CONFIG_FOLDER);
                 FileUtils.getOrCreateDirectory(serverConfigPath, "serverconfig");
-                final CommentedFileConfig data = config.getHandler().reader(serverConfigPath).apply(config);
-                ConfigHelper.setConfigData(config, data);
-                ModList.get().getModContainerById(config.getModId()).ifPresent(container -> {
-                    WorldSelectionScreen.this.minecraft.displayGuiScreen(new ConfigScreen(parent, new StringTextComponent(worldName), config, background));
+                config.loadServerConfig(serverConfigPath, T -> {
+                    ModList.get().getModContainerById(T.getModId()).ifPresent(container -> {
+                        WorldSelectionScreen.this.minecraft.displayGuiScreen(new ConfigScreen(parent, new StringTextComponent(worldName), T, background));
+                    });                	
                 });
             }
             catch(IOException e)

--- a/src/main/java/com/mrcrayfish/configured/impl/ForgeConfig.java
+++ b/src/main/java/com/mrcrayfish/configured/impl/ForgeConfig.java
@@ -1,0 +1,118 @@
+package com.mrcrayfish.configured.impl;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayDeque;
+import java.util.List;
+import java.util.Queue;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import com.electronwill.nightconfig.core.CommentedConfig;
+import com.electronwill.nightconfig.core.file.CommentedFileConfig;
+import com.mrcrayfish.configured.Configured;
+import com.mrcrayfish.configured.api.IConfigEntry;
+import com.mrcrayfish.configured.api.IConfigValue;
+import com.mrcrayfish.configured.api.IModConfig;
+import com.mrcrayfish.configured.client.screen.ListMenuScreen;
+import com.mrcrayfish.configured.util.ConfigHelper;
+
+import net.minecraftforge.fml.config.ModConfig;
+import net.minecraftforge.fml.config.ModConfig.Type;
+
+public class ForgeConfig implements IModConfig
+{
+	ModConfig config;
+	
+	public ForgeConfig(ModConfig config)
+	{
+		this.config = config;
+	}
+
+	@Override
+	public void saveConfig(IConfigEntry entry)
+	{
+        CommentedConfig newConfig = CommentedConfig.copy(this.config.getConfigData());
+        Queue<IConfigEntry> found = new ArrayDeque<>();
+        found.add(entry);
+        while(!found.isEmpty())
+        {
+        	IConfigEntry toSave = found.poll();
+        	if(!toSave.isLeaf())
+        	{
+        		found.addAll(toSave.getChildren());
+        		continue;
+        	}
+        	IConfigValue<?> value = toSave.getValue();
+        	if(value == null || !value.isChanged()) continue;
+        	if(value instanceof ForgeValue)
+        	{
+        		ForgeValue<?> forge = (ForgeValue<?>)value;
+        		if(forge instanceof ForgeListValue)
+        		{
+        			ForgeListValue forgeList = (ForgeListValue)value;
+                    Function<List<?>, List<?>> converter = forgeList.getConverter();
+                    if(converter != null)
+                    {
+                        newConfig.set(forge.configValue.getPath(), converter.apply(forgeList.get()));
+                        continue;
+                    }
+        		}
+                newConfig.set(forge.configValue.getPath(), value.get());
+        	}
+        }
+        this.config.getConfigData().putAll(newConfig);
+        if(getConfigType() == Type.SERVER)
+        {
+            if(!ListMenuScreen.isPlayingGame())
+            {
+                // Unload server configs since still in main menu
+                this.config.getHandler().unload(this.config.getFullPath().getParent(), this.config);
+                ConfigHelper.setConfigData(this.config, null);
+            }
+            else
+            {
+                ConfigHelper.sendConfigDataToServer(this.config);
+            }
+        }
+        else
+        {
+            Configured.LOGGER.info("Sending config reloading event for {}", this.config.getFileName());
+            this.config.getSpec().afterReload();
+            ConfigHelper.fireEvent(this.config, ConfigHelper.reloadingEvent(this.config));
+        }
+	}
+	
+	@Override
+	public IConfigEntry getRoot()
+	{
+		return new ForgeFolderEntry("Root", config.getSpec().getValues(), config.getSpec(), true);
+	}
+
+	@Override
+	public Type getConfigType()
+	{
+		return config.getType();
+	}
+
+	@Override
+	public String getFileName()
+	{
+		return config.getFileName();
+	}
+
+	@Override
+	public String getModId()
+	{
+		return config.getModId();
+	}
+
+	@Override
+	public void loadServerConfig(Path path, Consumer<IModConfig> result) throws IOException
+	{
+        final CommentedFileConfig data = config.getHandler().reader(path).apply(config);
+        ConfigHelper.setConfigData(config, data);
+        result.accept(this);
+	}
+	
+}

--- a/src/main/java/com/mrcrayfish/configured/impl/ForgeFolderEntry.java
+++ b/src/main/java/com/mrcrayfish/configured/impl/ForgeFolderEntry.java
@@ -1,0 +1,84 @@
+package com.mrcrayfish.configured.impl;
+
+import java.util.List;
+
+import com.electronwill.nightconfig.core.UnmodifiableConfig;
+import com.google.common.collect.ImmutableList;
+import com.mrcrayfish.configured.api.IConfigEntry;
+import com.mrcrayfish.configured.api.IConfigValue;
+import com.mrcrayfish.configured.api.ValueEntry;
+
+import net.minecraftforge.common.ForgeConfigSpec;
+
+public class ForgeFolderEntry implements IConfigEntry
+{
+    private final String label;
+    private final UnmodifiableConfig config;
+    private final ForgeConfigSpec spec;
+    private final boolean root;
+    private List<IConfigEntry> entries;
+	
+	public ForgeFolderEntry(String label, UnmodifiableConfig config, ForgeConfigSpec spec, boolean root)
+	{
+		this.label = label;
+		this.config = config;
+		this.spec = spec;
+		this.root = root;
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public List<IConfigEntry> getChildren()
+	{
+		if(entries == null)
+		{
+            ImmutableList.Builder<IConfigEntry> builder = ImmutableList.builder();
+            this.config.valueMap().forEach((s, o) ->
+            {
+                if(o instanceof UnmodifiableConfig)
+                {
+                    builder.add(new ForgeFolderEntry(s, (UnmodifiableConfig) o, this.spec, false));
+                }
+                else if(o instanceof ForgeConfigSpec.ConfigValue<?>)
+                {
+                    ForgeConfigSpec.ConfigValue<?> configValue = (ForgeConfigSpec.ConfigValue<?>)o;
+                    if(configValue.get() instanceof List)
+                    {
+                        builder.add(new ValueEntry(new ForgeListValue((ForgeConfigSpec.ConfigValue<List<?>>)configValue, spec.getRaw(configValue.getPath()))));                    	
+                    }
+                    else
+                    {
+                        builder.add(new ValueEntry(new ForgeValue<>(configValue, spec.getRaw(configValue.getPath()))));
+
+                    }
+                }
+            });
+            this.entries = builder.build();
+		}
+		return entries;
+	}
+	
+	@Override
+	public boolean isRoot()
+	{
+		return root;
+	}
+	
+	@Override
+	public boolean isLeaf()
+	{
+		return false;
+	}
+	
+	@Override
+	public IConfigValue<?> getValue()
+	{
+		return null;
+	}
+	
+	@Override
+	public String getEntryName()
+	{
+		return label;
+	}
+}

--- a/src/main/java/com/mrcrayfish/configured/impl/ForgeListValue.java
+++ b/src/main/java/com/mrcrayfish/configured/impl/ForgeListValue.java
@@ -1,0 +1,51 @@
+package com.mrcrayfish.configured.impl;
+
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.function.Function;
+
+import javax.annotation.Nullable;
+
+import net.minecraftforge.common.ForgeConfigSpec;
+import net.minecraftforge.common.ForgeConfigSpec.ConfigValue;
+import net.minecraftforge.common.ForgeConfigSpec.ValueSpec;
+
+public class ForgeListValue extends ForgeValue<List<?>>
+{
+    private final Function<List<?>, List<?>> converter;
+	
+	public ForgeListValue(ConfigValue<List<?>> configValue, ValueSpec valueSpec)
+	{
+		super(configValue, valueSpec);
+		converter = createConverter(configValue);
+	}
+	
+    @Nullable
+    private Function<List<?>, List<?>> createConverter(ForgeConfigSpec.ConfigValue<List<?>> configValue)
+    {
+        List<?> original = configValue.get();
+        if(original instanceof ArrayList)
+        {
+            return T -> new ArrayList<>(T);
+        }
+        else if(original instanceof LinkedList)
+        {
+            return T -> new LinkedList<>(T);
+        }
+        // TODO allow developers to hook custom list
+        return null;
+    }
+    
+    @Override
+    public void set(List<?> value)
+    {
+    	valueSpec.correct(value);
+    	super.set(new ArrayList<>(value));
+    }
+	
+	public Function<List<?>, List<?>> getConverter()
+	{
+		return converter;
+	}
+}

--- a/src/main/java/com/mrcrayfish/configured/impl/ForgeValue.java
+++ b/src/main/java/com/mrcrayfish/configured/impl/ForgeValue.java
@@ -1,0 +1,108 @@
+package com.mrcrayfish.configured.impl;
+
+import java.util.List;
+import java.util.Objects;
+
+import com.mrcrayfish.configured.api.IConfigValue;
+
+import net.minecraftforge.common.ForgeConfigSpec;
+
+public class ForgeValue<T> implements IConfigValue<T>
+{
+    public final ForgeConfigSpec.ConfigValue<T> configValue;
+    public final ForgeConfigSpec.ValueSpec valueSpec;
+    private final T initialValue;
+    protected T value;
+    
+    public ForgeValue(ForgeConfigSpec.ConfigValue<T> configValue, ForgeConfigSpec.ValueSpec valueSpec)
+    {
+        this.configValue = configValue;
+        this.valueSpec = valueSpec;
+        this.initialValue = configValue.get();
+        set(configValue.get());
+    }
+    
+	@Override
+	public T get()
+	{
+		return value;
+	}
+
+	@Override
+	public void set(T value)
+	{
+		this.value = value;
+	}
+
+	@Override
+	public boolean isDefault()
+	{
+		return Objects.equals(get(), valueSpec.getDefault());
+	}
+
+	@Override
+	public boolean isChanged()
+	{
+		return !Objects.equals(get(), initialValue);
+	}
+	
+	@Override
+	public void restore()
+	{
+		set(getDefault());
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public T getDefault()
+	{
+		return (T)valueSpec.getDefault();
+	}
+
+	@Override
+	public boolean isValid(T value)
+	{
+		return valueSpec.test(value);
+	}
+
+	@Override
+	public String getComment()
+	{
+		return valueSpec.getComment();
+	}
+
+	@Override
+	public String getTranslationKey()
+	{
+		return valueSpec.getTranslationKey();
+	}
+
+	@Override
+	public String getPath()
+	{
+		return lastValue(configValue.getPath(), "");
+	}
+	
+	@Override
+	public void cleanCache()
+	{
+		configValue.clearCache();
+	}
+
+	/**
+     * Gets the last element in a list
+     *
+     * @param list         the list of get the value from
+     * @param defaultValue if the list is empty, return this value instead
+     * @param <V>          the type of list
+     * @return the last element
+     */
+    public static <V> V lastValue(List<V> list, V defaultValue)
+    {
+        if(list.size() > 0)
+        {
+            return list.get(list.size() - 1);
+        }
+        return defaultValue;
+    }
+}


### PR DESCRIPTION
o/

This was a bit more work then expected.
I basically tore your mod apart and stitched it back together.

99% of forge dependencies are basically removed from this mod.
The only thing that's left inside of the mod that requires forge is the sync with server.
This has to be implemented by the person who wants to implement their custom config format anyways so that is fine.

Everything works now through "IModConfig", which basically creates a IConfigEntry (that is your IEntry) and these entries are auto converted to the elements that need them.

This whole refactor also cleaned up the code quite a bit because i was able to simplify a lot of the existing code.

I created a "api" folder which contains all the classes custom configs will need to create their stuff.
And also a helper class that allows to create custom Config Backgrounds without having to search through your mod.

Ofcourse you don't have to accept this patch but I thought I help out since this is kinda my strength in programming.

I tested a bit of things but I expect this not to be a flawless patch that still will require edge case fixes.
But everything that could be tested in singleplayer worked fine without a worry.
And I mostly moved code around and not change to much.

Also I plugged myself a tiny bit with Authors in the javaDoc.

Hope that helps. 