### PR TITLE
Compatibility with NightConfigFixes aka find ForgeConfigSpec when wrapped

### DIFF
--- a/src/main/java/com/mrcrayfish/configured/client/ClientHandler.java
+++ b/src/main/java/com/mrcrayfish/configured/client/ClientHandler.java
@@ -33,13 +33,7 @@ import net.minecraftforge.forgespi.language.IModInfo;
 import org.lwjgl.glfw.GLFW;
 
 import javax.annotation.Nullable;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -160,8 +154,7 @@ public class ClientHandler
         }
         catch(Exception e)
         {
-            Configured.LOGGER.error("An error occurred when loading configs from provider: {}", provider.getClass().getName());
-            e.printStackTrace();
+            Configured.LOGGER.error("An error occurred when loading configs from provider: {}", provider.getClass().getName(), e);
         }
         return Stream.empty();
     }

--- a/src/main/java/com/mrcrayfish/configured/impl/forge/ForgeConfig.java
+++ b/src/main/java/com/mrcrayfish/configured/impl/forge/ForgeConfig.java
@@ -29,18 +29,15 @@ public class ForgeConfig implements IModConfig
     });
 
     protected final ModConfig config;
+    protected final ForgeConfigSpec spec;
     protected final List<ForgeValueEntry> allConfigValues;
 
-    public ForgeConfig(ModConfig config)
+    public ForgeConfig(ModConfig config, ForgeConfigSpec spec)
     {
         this.config = config;
-        this.allConfigValues = getAllConfigValues(config);
-    }
-
-    protected ForgeConfig(ModConfig config, List<ForgeValueEntry> allConfigValues)
-    {
-        this.config = config;
-        this.allConfigValues = allConfigValues;
+        Objects.requireNonNull(spec, "spec is null");
+        this.spec = spec;
+        this.allConfigValues = getAllConfigValues(this.spec);
     }
 
     @Override
@@ -81,7 +78,7 @@ public class ForgeConfig implements IModConfig
         else if(!changedValues.isEmpty())
         {
             Configured.LOGGER.info("Sending config reloading event for {}", this.config.getFileName());
-            this.config.getSpec().afterReload();
+            this.spec.afterReload();
             ConfigHelper.fireForgeConfigEvent(this.config, new ModConfigEvent.Reloading(this.config));
         }
     }
@@ -89,7 +86,7 @@ public class ForgeConfig implements IModConfig
     @Override
     public IConfigEntry getRoot()
     {
-        return new ForgeFolderEntry(((ForgeConfigSpec) this.config.getSpec()).getValues(), (ForgeConfigSpec) this.config.getSpec());
+        return new ForgeFolderEntry(this.spec.getValues(), this.spec);
     }
 
     @Override
@@ -162,9 +159,9 @@ public class ForgeConfig implements IModConfig
         this.allConfigValues.forEach(pair -> pair.value.clearCache());
     }
 
-    protected List<ForgeValueEntry> getAllConfigValues(ModConfig config)
+    protected static List<ForgeValueEntry> getAllConfigValues(ForgeConfigSpec spec)
     {
-        return ConfigHelper.gatherAllForgeConfigValues(config).stream().map(pair -> new ForgeValueEntry(pair.getLeft(), pair.getRight())).toList();
+        return ConfigHelper.gatherAllForgeConfigValues(spec.getValues(), spec).stream().map(pair -> new ForgeValueEntry(pair.getLeft(), pair.getRight())).toList();
     }
 
     protected record ForgeValueEntry(ForgeConfigSpec.ConfigValue<?> value, ForgeConfigSpec.ValueSpec spec) {}

--- a/src/main/java/com/mrcrayfish/configured/impl/forge/ForgeConfigProvider.java
+++ b/src/main/java/com/mrcrayfish/configured/impl/forge/ForgeConfigProvider.java
@@ -4,17 +4,15 @@ import com.mrcrayfish.configured.Configured;
 import com.mrcrayfish.configured.api.IConfigProvider;
 import com.mrcrayfish.configured.api.IModConfig;
 import com.mrcrayfish.configured.client.util.OptiFineHelper;
+import com.mrcrayfish.configured.util.ConfigHelper;
 import net.minecraftforge.common.ForgeConfigSpec;
 import net.minecraftforge.fml.ModContainer;
 import net.minecraftforge.fml.config.ConfigTracker;
 import net.minecraftforge.fml.config.ModConfig;
-import net.minecraftforge.fml.util.ObfuscationReflectionHelper;
 
-import java.util.EnumMap;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 
 /**
  * Author: MrCrayfish
@@ -41,16 +39,14 @@ public class ForgeConfigProvider implements IConfigProvider
             return;
         }
 
-        Set<ModConfig> configSet = getForgeConfigSets().get(type);
-        Set<IModConfig> filteredConfigSets = configSet.stream()
-                .filter(config -> config.getModId().equals(container.getModId()) && config.getSpec() instanceof ForgeConfigSpec)
-                .map(ForgeConfig::new)
-                .collect(Collectors.toSet());
-        filteredConfigSets.forEach(consumer);
-    }
-
-    private static EnumMap<ModConfig.Type, Set<ModConfig>> getForgeConfigSets()
-    {
-        return ObfuscationReflectionHelper.getPrivateValue(ConfigTracker.class, ConfigTracker.INSTANCE, "configSets");
+        for (ModConfig config : ConfigTracker.INSTANCE.configSets().get(type)) {
+            if (config.getModId().equals(container.getModId())) {
+                ForgeConfigSpec forgeConfigSpec = ConfigHelper.findForgeConfigSpec(config.getSpec());
+                if (forgeConfigSpec != null) {
+                    ForgeConfig forgeConfig = new ForgeConfig(config, forgeConfigSpec);
+                    consumer.accept(forgeConfig);
+                }
+            }
+        }
     }
 }

--- a/src/main/java/com/mrcrayfish/configured/network/play/ServerPlayHandler.java
+++ b/src/main/java/com/mrcrayfish/configured/network/play/ServerPlayHandler.java
@@ -57,7 +57,8 @@ public class ServerPlayHandler
             return;
         }
 
-        if(!(config.getSpec() instanceof ForgeConfigSpec))
+        ForgeConfigSpec spec = ConfigHelper.findForgeConfigSpec(config.getSpec());
+        if(spec == null)
         {
             Configured.LOGGER.warn("Unable to process server config update due to unknown spec for config: {}", message.fileName());
             player.connection.disconnect(Component.translatable("configured.multiplayer.disconnect.bad_config_packet"));
@@ -67,7 +68,7 @@ public class ServerPlayHandler
         try
         {
             CommentedConfig data = TomlFormat.instance().createParser().parse(new ByteArrayInputStream(message.data()));
-            int result = ((ForgeConfigSpec) config.getSpec()).correct(data,
+            int result = spec.correct(data,
                     (action, path, incorrectValue, correctedValue) ->
                             Configured.LOGGER.warn("Incorrect key {} was corrected from {} to its default, {}. {}", DOT_JOINER.join(path), incorrectValue, correctedValue, incorrectValue == correctedValue ? "This seems to be an error." : ""),
                     (action, path, incorrectValue, correctedValue) ->


### PR DESCRIPTION
Hello there, my [Night Config Fixes](https://github.com/Fuzss/nightconfigfixes) mod wraps Forge's native `ForgeConfigSpec` implementation to be able to apply workarounds for some issues in Forge's implementation. Unfortunately this breaks Configured, which people seem to have noticed already, see #90.

It's very simple to fix on Configured's end though by simply unpacking instances of `UnmodifiableConfigWrapper` which is a built-in wrapper class from Night Config which is used by Forge and Night Config Fixes.

It would be great if you could accept this PR, since I'm not sure I'm even able to fix this issue on my end. There also doesn't seem to be another way besides wrapping `ForgeConfigSpec` for me to apply my necessary changes, since the class is part of FML and not Forge, meaning core mods cannot apply, which would have been my go-to more compatibility friendly approach otherwise.

Also <1.19.3 backports would be much appreciated, since Night Config Fixes is most of all a mod pack utility to prevent people from crashing, and those Minecraft versions simply are where most mod packs are at.