### PR TITLE
Fix crash parsing list entries

### DIFF
--- a/buildSrc/src/main/groovy/multiloader-common.gradle
+++ b/buildSrc/src/main/groovy/multiloader-common.gradle
@@ -41,25 +41,29 @@ repositories {
             includeGroupAndSubgroups("com.terraformersmc")
         }
     }
-    exclusiveContent {
-        forRepository {
-            maven {
-                name = "MrCrayfish (GitHub)"
-                url = "https://maven.pkg.github.com/MrCrayfish/Maven"
-                credentials {
-                    username = findProperty("gpr.user") ?: System.getenv("GPR_USER")
-                    password = findProperty("gpr.key") ?: System.getenv("GPR_KEY")
+    if (findProperty("gpr.user") ?: System.getenv("GPR_USER")) {
+        exclusiveContent {
+            forRepository {
+                maven {
+                    name = "MrCrayfish (GitHub)"
+                    url = "https://maven.pkg.github.com/MrCrayfish/Maven"
+                    credentials {
+                        username = findProperty("gpr.user") ?: System.getenv("GPR_USER")
+                        password = findProperty("gpr.key") ?: System.getenv("GPR_KEY")
+                    }
                 }
             }
-        }
-        filter {
-            includeGroupAndSubgroups("com.mrcrayfish")
+            filter {
+                includeGroupAndSubgroups("com.mrcrayfish")
+            }
         }
     }
-    if (!System.getenv("CI")) {
+    if (System.getenv("LOCAL_MAVEN") && !System.getenv("CI")) {
         maven {
-            url "file://" + System.getenv("LOCAL_MAVEN")
+            url "file://${System.getenv("LOCAL_MAVEN")}"
         }
+    } else {
+        mavenLocal()
     }
     maven {
         name = 'BlameJared'

--- a/gradle.properties
+++ b/gradle.properties
@@ -31,7 +31,7 @@ mod_issues=https://github.com/MrCrayfish/Configured/issues
 mod_license=GNU Lesser General Public License v3.0
 
 # Dependency options
-framework_version=0.8.8
+framework_version=0.8.13
 jei_version=17.3.0.48
 catalogue_version=1.10.1
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ fabric_version=0.97.8+1.20.6
 fabric_loader_version=0.15.10
 
 # NeoForge
-neoforge_version=20.6.48-beta
+neoforge_version=20.6.99-beta
 neoforge_version_range=[20.6,)
 neoforge_loader_version_range=[2,)
 


### PR DESCRIPTION
These changes resolve a crash when adding list entries due to NumberFormatExceptions (and other errors). I have chosen to resolve this by wrapping all parser functions with an error handler, guaranteeing that a crash can never occur, even with custom parsers. You may disagree with this or the choice to log suppressed exceptions, but I am open to feedback.

Confirmed fix in original project. No test coverage was needed (existing tests were failing)